### PR TITLE
Mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The following properties are configurable in your settings.json file:
 // The location to test from. The location is comprised of the location of the testing agent, the browser to test on, and the connectivity in the following format: location:browser.connectivity.
 "WebPageTest.location": "Dulles:Chrome.Cable",
 
+// skip the Repeat View test
+"WebPageTest.firstViewOnly": true,
+
 // The number of tests to run
 "WebPageTest.runs": 1,
 
@@ -35,6 +38,12 @@ The following properties are configurable in your settings.json file:
 
 // The maximum time (in seconds) to wait for test results
 "WebPageTest.timeout": 240,
+
+// emulate mobile browser: Chrome mobile user agent, 640x960 screen, 2x scaling and fixed viewport (Chrome only)
+"WebPageTest.emulateMobile": true,
+
+// The maximum time (in seconds) to wait for test results
+"WebPageTest.device": "MotoG4",
 ```
 [Find all the supported locations here.](https://webpagetest.org/getLocations.php?k=API_KEY&f=html)
 ### Running The Test

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following properties are configurable in your settings.json file:
 // emulate mobile browser: Chrome mobile user agent, 640x960 screen, 2x scaling and fixed viewport (Chrome only)
 "WebPageTest.emulateMobile": true,
 
-// The maximum time (in seconds) to wait for test results
+// device name from mobile_devices.ini (Link: https://github.com/WPO-Foundation/webpagetest/blob/master/www/settings/mobile_devices.ini) to use for mobile emulation (only when emulateMobile=true is specified to enable emulation and only for Chrome)
 "WebPageTest.device": "MotoG4",
 ```
 [Find all the supported locations here.](https://webpagetest.org/getLocations.php?k=API_KEY&f=html)

--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,9 @@ let options = {
 	"runs": 1,
 	"location": 'Dulles:Chrome.Cable',
 	"pollResults": 5,
-	"timeout": 240
+	"timeout": 240,
+	"emulateMobile": false,
+	"device": "MotoG4"
 }
 
 /**
@@ -30,6 +32,8 @@ async function activate(context) {
 			wpt_extension_config['pollResults'] = wpt_extension_config['pollResults'] || options['pollResults'];
 			wpt_extension_config['timeout'] = wpt_extension_config['timeout'] || options['timeout'];
 			wpt_extension_config['runs'] = wpt_extension_config['runs'] || options['runs'];
+			wpt_extension_config['emulateMobile'] = wpt_extension_config['emulateMobile'] === false ? false : options['emulateMobile'];
+			wpt_extension_config['device'] = wpt_extension_config['device'] || options['device'];
 
 			var panel = vscode.window.createWebviewPanel(
 				'webpagetest',


### PR DESCRIPTION
Now, Users can add parameter for emulateMobile & device in the extension config file (Settings.json).